### PR TITLE
A~0 Append to CFLAGS & LDFLAGS (dont overwrite)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -std=c11
+CFLAGS += -std=c11
 CFLAGS += -Wall
 CFLAGS += -Iinclude
 CFLAGS += -isystem/usr/local/include
@@ -8,7 +8,7 @@ CFLAGS += -Wno-switch
 CFLAGS += -Wno-unused-value
 CFLAGS += -Wno-unused-function
 CFLAGS += -D_GNU_SOURCE
-LDFLAGS ?= -L/usr/local/lib
+LDFLAGS += -L/usr/local/lib
 LDFLAGS += -lpthread
 LDFLAGS += -lm
 LDFLAGS += -lreadline


### PR DESCRIPTION
Notes:
- Allows devs to customize compile flags in their current env.
  Useful for devs who want to install dependencies in non-default
  locations.