### PR TITLE
Use package manager for all deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ RUN apt-get update \
     wget \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
-RUN ["sh", "-c", "git clone https://github.com/google/gumbo-parser.git && cd gumbo-parser/ && ./autogen.sh && ./configure && make && make install"]
+RUN ["sh", "-c", "git clone https://github.com/google/gumbo-parser.git && cd gumbo-parser/ && ./autogen.sh && ./configure && make && make install && rm /etc/ld.so.cache && ldconfig"]
 RUN ["sh", "-c", "cd /usr/src/ty/ && make clean && make && make install"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
     libsqlite3-dev \
     libssl-dev \
     libtool \
+    libgumbo-dev \
     libsodium-dev \
     libutf8proc-dev \
     make \
@@ -23,5 +24,4 @@ RUN apt-get update \
     wget \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
-RUN ["sh", "-c", "git clone https://github.com/google/gumbo-parser.git && cd gumbo-parser/ && ./autogen.sh && ./configure && make && make install && rm /etc/ld.so.cache && ldconfig"]
 RUN ["sh", "-c", "cd /usr/src/ty/ && make clean && make && make install"]


### PR DESCRIPTION
This allows the system to find the runtime gumbo libs required to run `ty`. Prior to this the user would have to work around this by refreshing ldconfig cache themseleves or setting `LD_LIBRARY_PATH=/usr/local/lib`.